### PR TITLE
fix appendice subsection overlapping. #7

### DIFF
--- a/xjtuthesis.cls
+++ b/xjtuthesis.cls
@@ -625,8 +625,8 @@
     \renewcommand\xjtuendcontent{
         \newpage
         \titleformat{\chapter}[block]{\sanhao}{}{0em}{\begin{center}}[\end{center}]
-        \titleformat{\section}[hang]{\xiaosan}{}{0em}{\thesection\quad }[\vskip -0.5em]
-        \titleformat{\subsection}{\sihao}{}{0em}{\vskip -1.5em \thesubsection\quad{}}
+        \titleformat{\section}[hang]{\xiaosan}{}{0em}{\thesection\quad}[]
+        \titleformat{\subsection}{\sihao}{}{0em}{\thesubsection\quad{}}
         \titleformat{\subsubsection}{}{}{0em}{\thesubsubsection\quad}[]
         \titlecontents{chapter}[0em]{}{\thecontentslabel\quad}{}{\dotfill\contentspage[{\makebox[0pt][r]{\thecontentspage}}]}
         \titlecontents{section}[1.5em]{}{\thecontentslabel\quad}{}{\dotfill\contentspage[{\makebox[0pt][r]{\thecontentspage}}]}


### PR DESCRIPTION
复现了 #7 中的问题（其实我之前就遇到了），一个 MWE：

```latex
\documentclass[
    bachelor,
    truefont,
]{xjtuthesis}
\begin{document}
    % \xjtucontent
    \xjtuendcontent
    \xjtuappendix
        \xjtuappendixchapter{附录}
        \xjtuappendixsection{二级标题}
        \xjtuappendixsubsection{三级标题}
    \xjtuendappendix
\end{document}
```

效果：

![原效果](https://user-images.githubusercontent.com/11963004/41366644-568f39e0-6f6f-11e8-8352-c658b1b544a8.png)

发现是 [非正文部分标题格式设置](https://github.com/Tedxz/xjtuthesis-x/blob/55ecfc26231fe2b455e5ba8fee4513a82aad492a/xjtuthesis.cls#L628) 的问题，想了很久还是没想明白为什么原作者要给 `subsection` 加上负的垂直偏移。但是将这个偏移去掉之后测试过 [比较复杂的附录内容](https://github.com/GenkunAbe/undergraduate-project-documents/releases/latest)，没有发现异常，所以认为可以去掉这个偏移。

去掉偏移后的效果：
![image](https://user-images.githubusercontent.com/11963004/41367391-77667c26-6f71-11e8-93a3-a3b5e12cef8f.png)

